### PR TITLE
docker - download latest stable vs by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
+# syntax=docker/dockerfile:1
 FROM mcr.microsoft.com/dotnet/runtime:7.0 as build
-ARG VS_VERSION=1.19.0-rc.6
-ARG VS_VERSION_TYPE=unstable
+ARG VS_VERSION
+ARG VS_VERSION_TYPE
+
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get install -y jq wget
 
 WORKDIR /tmp
-ADD https://cdn.vintagestory.at/gamefiles/${VS_VERSION_TYPE}/vs_server_linux-x64_${VS_VERSION}.tar.gz \
-    ./vs_server_linux-x64_${VS_VERSION}.tar.gz
+RUN <<EOF
+if [[ -n $VS_VERSION && -n $VS_VERSION_TYPE ]]; then
+    server_tarball_url=https://cdn.vintagestory.at/gamefiles/${VS_VERSION_TYPE}/vs_server_linux-x64_${VS_VERSION}.tar.gz
+else
+    wget https://api.vintagestory.at/stable.json
+    server_tarball_url=$(jq -r ".[] | select(.linuxserver.latest == 1) | .linuxserver.urls.cdn" stable.json)
+fi
+wget -O vs_server_linux-x64.tar.gz $server_tarball_url
+EOF
 
 WORKDIR /opt/vintagestory
-RUN tar xzf /tmp/vs_server_linux-x64_${VS_VERSION}.tar.gz
+RUN tar xzf /tmp/vs_server_linux-x64.tar.gz
 RUN rm -rf VintagestoryServer \
     VintagestoryServer.deps.json \
     VintagestoryServer.dll \

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Runs Vintagestory Server in Docker using [official Microsoft .NET images](https:
 ### Requirements
 - Linux Arm64 server. Tested with Raspberry Pi 5 (Raspbian OS).
 - Install [Docker](https://www.docker.com/get-started/)
-- Install [Docker compose](https://docs.docker.com/compose/install/)
+- Install [Docker compose plugin](https://docs.docker.com/compose/install/linux/#install-using-the-repository)
 
 ### Prepare server config
 `serverconfig.json` contains mostly defaults (paths changed to work with the container). Any edits will make it into the server.
@@ -69,7 +69,7 @@ Runs Vintagestory Server in Docker using [official Microsoft .NET images](https:
 ### Run
 The following command will build an image using the provided Dockerfile, mount storage, run the server, and attach the terminal to it:
 ```bash
-docker-compose up -d && docker attach vintagestoryserverarm64_vsserver_1
+docker compose up -d && docker attach vintagestoryserverarm64-vsserver-1
 ```
 
 The first run will take longer, but eventually you should be able to type `/help` and hit enter to see how to interact with the server.
@@ -79,5 +79,5 @@ The first run will take longer, but eventually you should be able to type `/help
 * To save and shutdown, type `/stop` and hit enter.
 * Use `CTRL+P CTRL+Q` to detach terminal from the server.
 * `docker volume inspect vintagestoryserverarm64_vsdata` will show the storage mount.
-* `docker-compose down -v` will remove the container _along with the storage_ if you need to start over.
-* `docker-compose create --build` to force rebuild from Dockerfile - this may be needed when updating Dockerfile.
+* `docker compose down -v` will remove the container _along with the storage_ if you need to start over.
+* `docker compose up --build` to force rebuild from Dockerfile - this may be needed when updating Dockerfile.


### PR DESCRIPTION
* Addressing feedback https://github.com/anegostudios/VintagestoryServerArm64/pull/5#issuecomment-1921912330 to get the latest version by default.
* Switched to explicitly using docker compose v2 (which as of July 2023 is the only one receiving updates). You can probably still run with compose v1 if you explicitly set `DOCKER_BUILDKIT=1` in shell.