### PR TITLE
Publish UDP port for Docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - "42420:42420"
+      - "42420:42420/udp"
     restart: on-failure
     stdin_open: true
     tty: true


### PR DESCRIPTION
Publishing a port without specifying the protocol under `ports` configuration publishes the port as TCP by default, UDP needs to be specified explicitly.