### PR TITLE
Update docker image to .Net 10 for 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ RUN tar xzf /tmp/vs_server_linux-x64.tar.gz && \
 COPY ./server .
 
 # final runtime image
-FROM mcr.microsoft.com/dotnet/runtime:8.0
+FROM mcr.microsoft.com/dotnet/runtime:10.0
 
 WORKDIR /app
 COPY --from=build /opt/vintagestory .
 
+RUN userdel --remove ubuntu
 RUN useradd -m -u 1000 -U vintagestory
 ENV HOME=/home/vintagestory
 ENV VSDATADIR=$HOME/.config/VintagestoryData


### PR DESCRIPTION
Updated dotnet runtime from 8.0 to 10.0 for vintagestory 1.22.

The 10.0 runtime image now comes with its own `ubuntu` user with uid `1000` as ubuntu [is now the default](https://github.com/dotnet/dotnet-docker/issues/6526), this breaks the `useradd` step, so this pr also added a step that deletes it before creating our own user.